### PR TITLE
Build static MUSL target with vendored openssl

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,3 +21,12 @@ pretty_env_logger = "0"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_yaml = "0"
 zap-model = { version = "0", path = "../model" }
+
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library.
+# Necessary when cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -23,3 +23,11 @@ serde_json = "1"
 serde_yaml = "0"
 ssh2 = "0"
 url = "2"
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library.
+# Necessary when cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]


### PR DESCRIPTION
Rust is capable of building binaries which carry their own MUSL
libc internally for operation on almost any userspace provided that
the kernel ABI (signals and such) is compatible with the platform
target selected.
This project runs into OpenSSL dependency problems when building a
MUSL target as the host libraries are generally built for GNU.
Address the concern by providing a vendored openssl, which permits
building for the target via `cargo build --features vendored` with
the relevant release and target/toolchain invocation.

Testing:
  This patch is applied to our internal PKGBUILD, producing working
binaries.